### PR TITLE
Add cider-nrepl v0.37.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     start_path: doc
   - url: https://github.com/clojure-emacs/cider-nrepl.git
     branches: master
-    tags: ['v0.24.0', 'v0.25.1', 'v0.26.0']
+    tags: ['v0.24.0', 'v0.25.1', 'v0.26.0', 'v0.37.0']
     start_path: doc
 asciidoc:
   attributes:


### PR DESCRIPTION
n.b. there are quite a few other versions https://github.com/clojure-emacs/cider-nrepl/tags, but those might be considered transient.

I have no strong opinion - perhaps they'd add noise to users, or even have some negative SEO impact?